### PR TITLE
Make it respond to platform change from flutter inspector or Theme

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dialogs/flutter_dialogs.dart';
@@ -13,7 +11,6 @@ class ExampleApp extends StatelessWidget {
       title: 'Flutter Dialogs Example',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        platform: TargetPlatform.iOS,
       ),
       home: ExampleScreen(),
     );

--- a/lib/src/base_dialog.dart
+++ b/lib/src/base_dialog.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'dart:io';
-
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 typedef T BaseDialogBuilder<T>(BuildContext context);
@@ -12,13 +11,16 @@ abstract class BaseDialog<A extends Widget, I extends Widget>
     extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    if (Platform.isAndroid) {
-      return buildAndroidWidget(context);
-    } else if (Platform.isIOS) {
-      return buildiOSWidget(context);
-    }
+    final platform = Theme.of(context).platform;
 
-    throw UnsupportedError("Platform is not supported by this plugin.");
+    switch (platform) {
+      case TargetPlatform.android:
+        return buildAndroidWidget(context);
+      case TargetPlatform.iOS:
+        return buildiOSWidget(context);
+      default:
+        throw UnsupportedError("Platform is not supported by this plugin.");
+    }
   }
 
   A buildAndroidWidget(BuildContext context);

--- a/lib/src/platform_dialog.dart
+++ b/lib/src/platform_dialog.dart
@@ -4,25 +4,27 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'dart:io';
 
 Future<T> showPlatformDialog<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
   androidBarrierDismissible = false,
 }) {
-  if (Platform.isAndroid) {
-    return showDialog<T>(
-      context: context,
-      builder: builder,
-      barrierDismissible: androidBarrierDismissible,
-    );
-  } else if (Platform.isIOS) {
-    return showCupertinoDialog<T>(
-      context: context,
-      builder: builder,
-    );
-  } else {
-    throw UnsupportedError("Platform is not supported by this plugin.");
+  final platform = Theme.of(context).platform;
+
+  switch (platform) {
+    case TargetPlatform.android:
+      return showDialog<T>(
+        context: context,
+        builder: builder,
+        barrierDismissible: androidBarrierDismissible,
+      );
+    case TargetPlatform.iOS:
+      return showCupertinoDialog<T>(
+        context: context,
+        builder: builder,
+      );
+    default:
+      throw UnsupportedError("Platform is not supported by this plugin.");
   }
 }


### PR DESCRIPTION
Makes it possible to test the dialog look on both platforms just by
changing the platform from the flutter inspector, or by changing the
Theme.platform property

Resolves: #2